### PR TITLE
feat: fetch data with react-query

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>
-  <body class="bg-blue-50">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,3 @@
+body {
+  @apply bg-blue-50;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,18 +3,25 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { Home } from "./pages/Home";
 import { Matches } from "./pages/Matches";
 import { Nav } from "./components/Nav";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+const queryClient = new QueryClient();
 
 function App() {
   return (
-    <Router>
-      <Nav />
-      <Routes>
-        <Route path="/" element={<Home />}></Route>
-      </Routes>
-      <Routes>
-        <Route path="/matches" element={<Matches />}></Route>
-      </Routes>
-    </Router>
+    <QueryClientProvider client={queryClient}>
+      <Router>
+        <Nav />
+        <Routes>
+          <Route path="/" element={<Home />}></Route>
+        </Routes>
+        <Routes>
+          <Route path="/matches" element={<Matches />}></Route>
+        </Routes>
+      </Router>
+      <ReactQueryDevtools />
+    </QueryClientProvider>
   );
 }
 

--- a/src/components/MatchDays.tsx
+++ b/src/components/MatchDays.tsx
@@ -1,4 +1,12 @@
-export const MatchDays = ({
+import { FC } from "react"
+
+interface MatchDaysProps {
+  matchDays: number[]
+  selectedMatchday: number
+  handleMatchdaySelect: (matchday: number) => void
+}
+
+export const MatchDays: FC<MatchDaysProps> = ({
   matchDays,
   selectedMatchday,
   handleMatchdaySelect,
@@ -18,5 +26,5 @@ export const MatchDays = ({
         </li>
       ))}
     </ul>
-  );
-};
+  )
+}

--- a/src/components/MatchDays.tsx
+++ b/src/components/MatchDays.tsx
@@ -1,0 +1,22 @@
+export const MatchDays = ({
+  matchDays,
+  selectedMatchday,
+  handleMatchdaySelect,
+}) => {
+  return (
+    <ul className="flex flex-wrap list-none p-0">
+      {matchDays.map((matchDay) => (
+        <li key={matchDay} className="m-1">
+          <button
+            className={`text-blue-700 hover:underline ${
+              selectedMatchday === matchDay ? `underline` : ``
+            }`}
+            onClick={() => handleMatchdaySelect(matchDay)}
+          >
+            {matchDay}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/components/TodaysMatches.tsx
+++ b/src/components/TodaysMatches.tsx
@@ -1,7 +1,73 @@
-export const TodaysMatches = ({ todaysMatches }) => {
+import { FC } from "react"
+
+export interface Match {
+  area: {
+    id: number
+    name: string
+    code: string
+    flag: string
+  }
+  competition: {
+    id: number
+    name: string
+    code: string
+    type: string
+    emblem: string
+  }
+  season: {
+    id: number
+    startDate: string
+    endDate: string
+    currentMatchday: number
+    winner: string | null
+  }
+  id: number
+  utcDate: string
+  status: string
+  matchday: number
+  stage: number
+  group: string | null
+  lastUpdated: string
+  homeTeam: {
+    id: number
+    name: string
+    shortName: string
+    tla: string
+    crest: string
+  }
+  awayTeam: {
+    id: number
+    name: string
+    shortName: string
+    tla: string
+    crest: string
+  }
+  score: {
+    winner: string | null
+    duration: string
+    fullTime: {
+      home: string | null
+      away: string | null
+    }
+    halfTime: {
+      home: string | null
+      away: string | null
+    }
+  }
+  odds: {
+    msg: string
+  }
+  referees: []
+}
+
+interface TodaysMatchesProp {
+  todaysMatches: Match[]
+}
+
+export const TodaysMatches: FC<TodaysMatchesProp> = ({ todaysMatches }) => {
   return (
     <ul>
-      {todaysMatches.map((match) => (
+      {todaysMatches.map((match: Match) => (
         <li key={match.id}>
           <div className="flex items-center">
             <img src={match.homeTeam.crest} className="w-5 h-5 mr-1" />
@@ -12,5 +78,5 @@ export const TodaysMatches = ({ todaysMatches }) => {
         </li>
       ))}
     </ul>
-  );
-};
+  )
+}

--- a/src/components/TodaysMatches.tsx
+++ b/src/components/TodaysMatches.tsx
@@ -1,0 +1,16 @@
+export const TodaysMatches = ({ todaysMatches }) => {
+  return (
+    <ul>
+      {todaysMatches.map((match) => (
+        <li key={match.id}>
+          <div className="flex items-center">
+            <img src={match.homeTeam.crest} className="w-5 h-5 mr-1" />
+            {match.homeTeam.shortName} vs<span className="ml-2"></span>
+            <img src={match.awayTeam.crest} className="w-5 h-5 mr-1" />
+            {match.awayTeam.shortName}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,3 +1,7 @@
 export const Home = () => {
-  return <h1>Home</h1>;
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-4">Home</h1>
+    </div>
+  );
 };

--- a/src/pages/Matches.tsx
+++ b/src/pages/Matches.tsx
@@ -5,11 +5,18 @@ import { MatchDays } from "../components/MatchDays"
 import { TodaysMatches } from "../components/TodaysMatches"
 import { Match } from "../components/TodaysMatches"
 
+type MatchData = {
+  competition: {}
+  filters: {}
+  matches: Match[]
+  resultSet: {}
+}
+
 export const Matches = () => {
   const [todaysMatches, setTodaysMatches] = useState<Match[]>([])
   const [selectedMatchday, setSelectedMatchday] = useState<number>(6)
 
-  const { isLoading, isError, data, error } = useQuery<any, Error>({
+  const { isLoading, isError, data, error } = useQuery<MatchData, Error>({
     queryKey: ["matches", selectedMatchday],
     queryFn: () => getMatches(selectedMatchday),
   })
@@ -17,6 +24,7 @@ export const Matches = () => {
   useEffect(() => {
     if (data) {
       setTodaysMatches(data.matches)
+      console.log(data)
     }
   }, [data, selectedMatchday])
 

--- a/src/pages/Matches.tsx
+++ b/src/pages/Matches.tsx
@@ -1,37 +1,34 @@
-import { useEffect, useState } from "react";
-import { getMatches } from "../services/matches";
-import { useQuery } from "@tanstack/react-query";
-import { MatchDays } from "../components/MatchDays";
-import { TodaysMatches } from "../components/TodaysMatches";
+import { useEffect, useState } from "react"
+import { getMatches } from "../services/matches"
+import { useQuery } from "@tanstack/react-query"
+import { MatchDays } from "../components/MatchDays"
+import { TodaysMatches } from "../components/TodaysMatches"
+import { Match } from "../components/TodaysMatches"
 
 export const Matches = () => {
-  const [todaysMatches, setTodaysMatches] = useState([]);
-  const [selectedMatchday, setSelectedMatchday] = useState(6);
+  const [todaysMatches, setTodaysMatches] = useState<Match[]>([])
+  const [selectedMatchday, setSelectedMatchday] = useState<number>(6)
 
-  const { isLoading, isError, data, error } = useQuery({
+  const { isLoading, isError, data, error } = useQuery<any, Error>({
     queryKey: ["matches", selectedMatchday],
     queryFn: () => getMatches(selectedMatchday),
-  });
-
-  const handleMatchdaySelect = (matchday) => {
-    setSelectedMatchday(matchday);
-  };
+  })
 
   useEffect(() => {
     if (data) {
-      setTodaysMatches(data.matches);
+      setTodaysMatches(data.matches)
     }
-  }, [data, selectedMatchday]);
+  }, [data, selectedMatchday])
 
   if (isLoading) {
-    return <span>Loading...</span>;
+    return <span>Loading...</span>
   }
 
   if (isError) {
-    return <span>Error: {error.message}</span>;
+    return <span>Error: {error.message}</span>
   }
 
-  const matchDays = Array.from({ length: 36 }, (_, index) => index + 1);
+  const matchDays = Array.from({ length: 36 }, (_, index) => index + 1)
 
   return (
     <div className="p-4">
@@ -43,9 +40,9 @@ export const Matches = () => {
       <MatchDays
         matchDays={matchDays}
         selectedMatchday={selectedMatchday}
-        handleMatchdaySelect={handleMatchdaySelect}
+        handleMatchdaySelect={setSelectedMatchday}
       />
       <TodaysMatches todaysMatches={todaysMatches} />
     </div>
-  );
-};
+  )
+}

--- a/src/pages/Matches.tsx
+++ b/src/pages/Matches.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { getMatches } from "../services/matches";
 import { useQuery } from "@tanstack/react-query";
+import { MatchDays } from "../components/MatchDays";
+import { TodaysMatches } from "../components/TodaysMatches";
 
 export const Matches = () => {
   const [todaysMatches, setTodaysMatches] = useState([]);
@@ -29,12 +31,6 @@ export const Matches = () => {
     return <span>Error: {error.message}</span>;
   }
 
-  console.log(todaysMatches);
-
-  // const matchDaysList = () => {
-  //   const matchDays = Array.from({length: 36}, (_, index) => index + 1)
-  // }
-
   const matchDays = Array.from({ length: 36 }, (_, index) => index + 1);
 
   return (
@@ -44,32 +40,12 @@ export const Matches = () => {
           ? `English Premier League Matches for Day ${todaysMatches[0].matchday}`
           : "Loading..."}
       </h1>
-      <ul className="flex flex-wrap list-none p-0">
-        {matchDays.map((matchDay) => (
-          <li key={matchDay} className="m-1">
-            <button
-              className={`text-blue-700 hover:underline ${
-                selectedMatchday === matchDay ? `underline` : ``
-              }`}
-              onClick={() => handleMatchdaySelect(matchDay)}
-            >
-              {matchDay}
-            </button>
-          </li>
-        ))}
-      </ul>
-      <ul>
-        {todaysMatches.map((match) => (
-          <li key={match.id}>
-            <div className="flex items-center">
-              <img src={match.homeTeam.crest} className="w-5 h-5 mr-1" />
-              {match.homeTeam.shortName} vs<span className="ml-2"></span>
-              <img src={match.awayTeam.crest} className="w-5 h-5 mr-1" />
-              {match.awayTeam.shortName}
-            </div>
-          </li>
-        ))}
-      </ul>
+      <MatchDays
+        matchDays={matchDays}
+        selectedMatchday={selectedMatchday}
+        handleMatchdaySelect={handleMatchdaySelect}
+      />
+      <TodaysMatches todaysMatches={todaysMatches} />
     </div>
   );
 };

--- a/src/pages/Matches.tsx
+++ b/src/pages/Matches.tsx
@@ -1,3 +1,75 @@
+import { useEffect, useState } from "react";
+import { getMatches } from "../services/matches";
+import { useQuery } from "@tanstack/react-query";
+
 export const Matches = () => {
-  return <h1>Matches</h1>;
+  const [todaysMatches, setTodaysMatches] = useState([]);
+  const [selectedMatchday, setSelectedMatchday] = useState(6);
+
+  const { isLoading, isError, data, error } = useQuery({
+    queryKey: ["matches", selectedMatchday],
+    queryFn: () => getMatches(selectedMatchday),
+  });
+
+  const handleMatchdaySelect = (matchday) => {
+    setSelectedMatchday(matchday);
+  };
+
+  useEffect(() => {
+    if (data) {
+      setTodaysMatches(data.matches);
+    }
+  }, [data, selectedMatchday]);
+
+  if (isLoading) {
+    return <span>Loading...</span>;
+  }
+
+  if (isError) {
+    return <span>Error: {error.message}</span>;
+  }
+
+  console.log(todaysMatches);
+
+  // const matchDaysList = () => {
+  //   const matchDays = Array.from({length: 36}, (_, index) => index + 1)
+  // }
+
+  const matchDays = Array.from({ length: 36 }, (_, index) => index + 1);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-4">
+        {todaysMatches.length > 0
+          ? `English Premier League Matches for Day ${todaysMatches[0].matchday}`
+          : "Loading..."}
+      </h1>
+      <ul className="flex flex-wrap list-none p-0">
+        {matchDays.map((matchDay) => (
+          <li key={matchDay} className="m-1">
+            <button
+              className={`text-blue-700 hover:underline ${
+                selectedMatchday === matchDay ? `underline` : ``
+              }`}
+              onClick={() => handleMatchdaySelect(matchDay)}
+            >
+              {matchDay}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <ul>
+        {todaysMatches.map((match) => (
+          <li key={match.id}>
+            <div className="flex items-center">
+              <img src={match.homeTeam.crest} className="w-5 h-5 mr-1" />
+              {match.homeTeam.shortName} vs<span className="ml-2"></span>
+              <img src={match.awayTeam.crest} className="w-5 h-5 mr-1" />
+              {match.awayTeam.shortName}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 };

--- a/src/pages/Matches.tsx
+++ b/src/pages/Matches.tsx
@@ -24,7 +24,6 @@ export const Matches = () => {
   useEffect(() => {
     if (data) {
       setTodaysMatches(data.matches)
-      console.log(data)
     }
   }, [data, selectedMatchday])
 

--- a/src/services/matches.ts
+++ b/src/services/matches.ts
@@ -1,9 +1,9 @@
-import { API_KEY } from "../utils/constants";
+import { API_KEY } from "../utils/constants"
 
-export const getMatches = (matchday) => {
+export const getMatches = (matchday: number) => {
   return fetch(`api/v4/competitions/PL/matches?matchday=${matchday}`, {
     headers: {
       "X-Auth-Token": API_KEY,
     },
-  }).then((response) => response.json());
-};
+  }).then((response) => response.json())
+}

--- a/src/services/matches.ts
+++ b/src/services/matches.ts
@@ -1,5 +1,7 @@
-export const getMatches = () => {
-  return fetch("api/v4/competitions/PL/matches?matchday=6", {
+import { API_KEY } from "../utils/constants";
+
+export const getMatches = (matchday) => {
+  return fetch(`api/v4/competitions/PL/matches?matchday=${matchday}`, {
     headers: {
       "X-Auth-Token": API_KEY,
     },


### PR DESCRIPTION
[TRAINING-9](https://youtrack.sourcelab.bg/youtrack/issue/TRAINING-9/Fetch-Football-Data-with-react-query)

**Define the problem**

- Football data should be fetched from the API using react-query
- The data should be visualised in a user friendly format
- The data should be updated when needed

**Solution**

- I've used react-query to fetch data for the matches of each matchday in the English Premier League
- I've vusialised the data in the Matches page
- There is a list with the matchdays and when the user clicks on particular matchday then the matches for that matchday appear
- Because of the limitation of the API, when too many request are made for very short timespan there might be an error but otherwise it seems to be working as expected